### PR TITLE
Fix logout redirect issue in UI by updating redirect path from uiv2 to uiv3 in alternate.js

### DIFF
--- a/web/cass/uiv3/js/alterante.js
+++ b/web/cass/uiv3/js/alterante.js
@@ -257,7 +257,7 @@
 			try {
 				var data = xhr.responseText;
 				if (data == null || data == undefined || data == '') {
-					document.location.href = "/cass/uiv2/indexv2.htm";
+					document.location.href = "/cass/uiv3/indexv2.htm";
 				}
 			} catch (e) {
 			}
@@ -267,7 +267,7 @@
 			try {
 				var data = xhr.responseText;
 				if (data == null || data == undefined || data == '') {
-					document.location.href = "/cass/uiv2/indexv2.htm";
+					document.location.href = "/cass/uiv3/indexv2.htm";
 				}
 			} catch (e) {
 			}
@@ -277,7 +277,7 @@
 			try {
 				var data = xhr.responseText;
 				if (data == null || data == undefined || data == '') {
-					document.location.href = "/cass/uiv2/indexv2.htm";
+					document.location.href = "/cass/uiv3/indexv2.htm";
 				}
 			} catch (e) {
 			}


### PR DESCRIPTION
…Resolved an issue where users were redirected to /cass/uiv2/indexv2.htm after logout.

🔧 Updated alterante.js to point to the correct path /cass/uiv3/indexv2.htm

💡 This ensures the current UI version loads properly post-logout.

Tested locally with multiple login/logout attempts.